### PR TITLE
Back end does not returned soft deleted rows but does if related to an Opp

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -14,8 +14,8 @@ const sequelize = new Sequelize(
     dialect: 'postgres',
     logging: false,
     define: {
+      paranoid: true,
       underscored: true,
-      timestamps: false,
       freezeTableName: true
     }
   },

--- a/src/schema/opp.js
+++ b/src/schema/opp.js
@@ -27,9 +27,9 @@ extend type Query {
 let resolvers = {
   Opp: {
     author: (opp) => opp.getUser(),
-    role: (opp) => opp.getRole(),
-    tools: (opp) => opp.getTools(),
-    team: (opp) => opp.getTeam()
+    role: (opp) => opp.getRole({ paranoid: false }),
+    tools: (opp) => opp.getTools({ paranoid: false }),
+    team: (opp) => opp.getTeam({ paranoid: false })
   },
   Query: {
     opp: (_, { id }) => Opp.findById(id),


### PR DESCRIPTION
Important because bookmarked Opps by definition are "time capsules", thus the associations (role, tools, team) that generated them should be included.